### PR TITLE
optional request schema

### DIFF
--- a/src/express.ts
+++ b/src/express.ts
@@ -97,8 +97,8 @@ export function createRouter(expressRouter = PromiseRouter()): Router {
     use(endpoint, ...handlers) {
       const validateRequest: Express.RequestHandler = (req, res, next) => {
         // Skip validation if this endpoint does not have a request schema
-        // (E.g. it's method is GET/HEAD)
-        if ("request" in endpoint) {
+        // (E.g. it's method is GET/HEAD, or the user didn't provide one)
+        if ("request" in endpoint && endpoint.request != null) {
           const result = endpoint.request.safeParse(req.body);
 
           /**

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -32,7 +32,7 @@ export type FetchOptions<
   // Only include the params key if the pattern actually has params
   (keyof Params<Pattern> extends never ? {} : { params: Params<Pattern> }) &
   // Only include the body key if the http method can accept a body
-  (Method extends HttpMethodWithoutBody ? {} : { body: Request })
+  (Method extends HttpMethodWithoutBody ? {} : Request extends unknown ? {} : { body: Request })
 );
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,8 @@ export type Endpoint<
 > = Method extends HttpMethodWithBody ? {
   path: Path<Pattern>;
   method: Method;
+  request?: z.ZodType<Request>;
   response: z.ZodType<Response>;
-  request: z.ZodType<Request>;
 } : {
   path: Path<Pattern>;
   method: Method;

--- a/tests/endpoint-without-request-schema.ts
+++ b/tests/endpoint-without-request-schema.ts
@@ -1,0 +1,42 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import { path } from "static-path";
+import { z } from "zod";
+import { fetchJson } from "../src/fetch";
+import { createRouter } from "../src/express";
+import { endpoint } from "../src";
+import { listen } from "./_helpers";
+
+let logout = endpoint({
+  path: path("/logout"),
+  method: "post",
+  response: z.object({ ok: z.boolean() }),
+});
+
+let router = createRouter();
+
+router.use(logout, (req, res) => {
+  res.json({ ok: true });
+});
+
+test("endpoint without request schema", async () => {
+  let [baseUrl, done] = listen(router);
+
+  {
+    // Call without a body parameter shouldn't be a type error
+    let response = await fetchJson(logout, { baseUrl });
+    assert.equal(response, { ok: true });
+  }
+
+  {
+    await fetchJson(logout, {
+      baseUrl,
+      // @ts-expect-error (It's an error to pass a body to this endpoint)
+      body: { lhs: 1, rhs: 2 },
+    });
+  }
+
+  await done();
+});
+
+test.run();


### PR DESCRIPTION
Don't require a `request` schema for `HttpMethodWithBody` endpoints.

```ts
const test = endpoint({
  method: "delete",
  response: z.object({ ok: z.literal(true) }),
  // no request schema needed!
});
```

Enforced at the router:

```ts
router.use(test, (req, res) => {
  req.body // unknown
});
```

Enforced at the client:

```ts
fetchJson(test, {
  // this is a type error
  body: JSON.stringify({}),
});
```